### PR TITLE
Update: FortiClient 7.4 on Ubuntu 22.04 LTS; add desktop & VPN-only e…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,58 +1,71 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ENV TZ=America/Montreal
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update
-RUN apt-get install -y ipppd expect wget net-tools ca-certificates iproute2 iptables ssh curl gnupg polipo && \
-    apt-get install -y gcc-4.9 make libpam0g-dev libldap2-dev libssl-dev && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /root
 
-## Install fortivpn client unofficial .deb
-#RUN wget 'https://hadler.me/files/forticlient-sslvpn_4.4.2332-1_amd64.deb' -O forticlient-sslvpn_amd64.deb
-#RUN dpkg -x forticlient-sslvpn_amd64.deb /usr/share/forticlient
+# Install build dependencies and runtime packages
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc make libpam0g-dev libldap2-dev libssl-dev \
+    wget ca-certificates gnupg && \
+    rm -rf /var/lib/apt/lists/*
 
-## Install official client
-RUN wget --no-check-certificate -O- https://repo.fortinet.com/repo/7.0/ubuntu/DEB-GPG-KEY | apt-key add -
-#RUN wget --no-check-certificate -vO - https://repo.fortinet.com/repo/7.0/ubuntu/DEB-GPG-KEY | gpg --dearmor > /usr/share/keyrings/fortinet-archive-keyring.gpg
-RUN DEBIAN_FRONTEND=noninteractive echo "deb [arch=amd64] https://repo.fortinet.com/repo/7.0/ubuntu/ /bionic multiverse:" >> /etc/apt/sources.list \
-    && apt-get update \
-    && apt install forticlient \
-    && apt-get clean
+### Install FortiClient 7.4 from official repository
+### Use gpg --dearmor to handle GPG key importing for newer Ubuntu versions
+RUN wget -O - https://repo.fortinet.com/repo/forticlient/7.4/ubuntu22/DEB-GPG-KEY | gpg --dearmor | tee /usr/share/keyrings/repo.fortinet.com.gpg && \
+    DEBIAN_FRONTEND=noninteractive echo "deb [arch=amd64 signed-by=/usr/share/keyrings/repo.fortinet.com.gpg] https://repo.fortinet.com/repo/forticlient/7.4/ubuntu22/ stable non-free" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends forticlient && \
+    rm -rf /var/lib/apt/lists/*
 
-# Install SS5
-RUN wget -O ss5.tar.gz "http://downloads.sourceforge.net/project/ss5/ss5/3.8.9-8/ss5-3.8.9-8.tar.gz"
+# Install runtime dependencies and minimal XFCE4 desktop
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y --no-install-recommends \
+    tinyproxy expect wget net-tools ca-certificates iproute2 iptables ssh curl \
+    xdg-utils libnss3 libasound2 libgconf-2-4 libgtk-3-0 libuuid1 libsecret-1-0 \
+    xfce4 xfce4-terminal xfce4-panel xfce4-session xfce4-settings thunar \
+    xfce4-whiskermenu-plugin dbus dbus-x11 x11-utils xauth \
+    libcanberra-gtk-module libcanberra-gtk3-module libcanberra0 libnotify-bin \
+    policykit-1 at-spi2-core pm-utils \
+    xserver-xephyr xvfb x11vnc pulseaudio-utils libpulse0 x11-xserver-utils && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN groupadd -r ss5 && useradd -r -g ss5 ss5 && \
-  mkdir -p /usr/src/ss5 \
-  && tar -xzf ss5.tar.gz -C /usr/src/ss5 --strip-components=1 \
-  && rm ss5.tar.gz \
-  && cd /usr/src/ss5 \
-  && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc && touch /usr/src/gcc \
-  && ./configure \
-  && make \
-  && make install \
-  && cd / \
-  && rm /usr/src/gcc \
-  && apt-get purge -y --auto-remove gcc-4.9 make libpam0g-dev libldap2-dev libssl-dev \
-  && rm -rf /usr/src/ss5 \
-  && sed -i "/#auth/a\auth 0.0.0.0\/0 - -" /etc/opt/ss5/ss5.conf \
-  && sed -i "/#permit/a\permit - 0.0.0.0\/0 - 0.0.0.0\/0 - - - - -" /etc/opt/ss5/ss5.conf \
-  && touch /var/log/ss5/ss5.log
+### Install Dante SOCKS5 server (modern alternative to SS5)
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y --no-install-recommends dante-server && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /var/log/dante && \
+    chown -R nobody:nogroup /var/log/dante
 
-RUN rm -rf /var/lib/apt/lists/*
+# Configure Dante SOCKS5 server
+RUN echo "# Dante SOCKS5 configuration" > /etc/danted.conf && \
+    echo "internal: 0.0.0.0 port = 1080" >> /etc/danted.conf && \
+    echo "external: 0.0.0.0" >> /etc/danted.conf && \
+    echo "" >> /etc/danted.conf && \
+    echo "client pass {" >> /etc/danted.conf && \
+    echo "    from: 0.0.0.0/0 to: 0.0.0.0/0" >> /etc/danted.conf && \
+    echo "}" >> /etc/danted.conf && \
+    echo "" >> /etc/danted.conf && \
+    echo "socks pass {" >> /etc/danted.conf && \
+    echo "    from: 0.0.0.0/0 to: 0.0.0.0/0" >> /etc/danted.conf && \
+    echo "}" >> /etc/danted.conf
 
-# Run setup
-RUN /usr/share/forticlient/opt/forticlient-sslvpn/64bit/helper/setup 2
+# Configure tinyproxy for HTTP proxy on port 8123
+RUN sed -i 's/^Port 8888/Port 8123/' /etc/tinyproxy/tinyproxy.conf && \
+    sed -i 's/^# Allow 127.0.0.1/Allow 0.0.0.0\/0/' /etc/tinyproxy/tinyproxy.conf
 
-# Copy runfiles
+# Copy runfiles (These files need to be present in your local directory when building)
 COPY forticlient /usr/bin/forticlient
 COPY start.sh /start.sh
 COPY imap.py /imap.py
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
+# Expose ports: 1080 (Dante SOCKS5), 8123 (tinyproxy HTTP), VPN tunnel interface
 EXPOSE 1080
 EXPOSE 8123
 
-CMD [ "/start.sh" ]
+CMD [ "/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Entrypoint script for FortiClient VPN container
+# Supports both VPN-only mode and XFCE4 desktop mode
+
+set -e
+
+# Default mode: VPN only
+MODE="${MODE:-vpn}"
+
+# Function to start dbus and xfce4 session
+start_desktop() {
+    echo "Starting XFCE4 desktop environment..."
+    
+    # Reduce accessibility-related noisy warnings when running in container
+    export NO_AT_BRIDGE=1
+    export GTK_MODULES=
+
+    # Decide whether to use host DISPLAY or start a nested X server
+    HOST_DISPLAY="${DISPLAY:-}" 
+    if [ -n "$HOST_DISPLAY" ]; then
+        # If host X server is running, avoid replacing its window manager
+        if command -v xdpyinfo >/dev/null 2>&1 && xdpyinfo -display "$HOST_DISPLAY" >/dev/null 2>&1; then
+            echo "Detected host X server on $HOST_DISPLAY. Starting nested Xephyr on :1 to avoid conflicts."
+            # Start nested X server (Xephyr) on :1
+            Xephyr -br -noreset -screen 1280x800 :1 &
+            # wait for nested X
+            for i in $(seq 1 20); do
+                xdpyinfo -display :1 >/dev/null 2>&1 && break || sleep 0.5
+            done
+            export DISPLAY=":1"
+        else
+            export DISPLAY="$HOST_DISPLAY"
+        fi
+    else
+        # No host DISPLAY: start a virtual framebuffer
+        echo "No DISPLAY detected. Starting Xvfb on :1"
+        Xvfb :1 -screen 0 1280x800x24 &
+        for i in $(seq 1 20); do
+            xdpyinfo -display :1 >/dev/null 2>&1 && break || sleep 0.5
+        done
+        export DISPLAY=":1"
+    fi
+
+    # Start dbus session
+    eval $(dbus-launch --sh-syntax) || true
+    export DBUS_SESSION_BUS_ADDRESS
+    
+    # Start background services before XFCE4
+    echo "Starting FortiClient VPN..."
+    /usr/bin/forticlient &
+    FORTICLIENT_PID=$!
+    
+    # Start Dante SOCKS5 server
+    echo "Starting Dante SOCKS5 proxy..."
+    /usr/sbin/danted -f /etc/danted.conf &
+    DANTE_PID=$!
+    
+    # Start tinyproxy HTTP proxy
+    echo "Starting tinyproxy HTTP proxy..."
+    /usr/sbin/tinyproxy -d &
+    TINYPROXY_PID=$!
+    
+    # Start XFCE4 session on the chosen DISPLAY
+    echo "Starting XFCE4 session on $DISPLAY..."
+    exec startxfce4 --replace
+}
+
+# Function to start VPN-only mode (original behavior)
+start_vpn_only() {
+    echo "Starting in VPN-only mode..."
+    
+    # Run original start.sh logic
+    exec /start.sh
+}
+
+# Main routing logic
+case "$MODE" in
+    desktop|xfce)
+        start_desktop
+        ;;
+    vpn|vpn-only)
+        start_vpn_only
+        ;;
+    *)
+        echo "Unknown mode: $MODE"
+        echo "Valid modes: vpn (default), desktop, xfce"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
…ntrypoint

- Bump base to Ubuntu 22.04 LTS, install FortiClient 7.4 from official repo.
- Add optional XFCE4 desktop mode with modern proxies (Dante SOCKS5, tinyproxy HTTP).
- Introduce entrypoint.sh supporting both `vpn` (default, runs start.sh) and `desktop` (runs XFCE in nested/Xvfb display).
- Replace legacy SS5 with Dante for SOCKS5 proxy.
- Fix X11/DBus/GTK module and accessibility issues for GUI mode.
- Preserve original VPN-only workflow for backward compatibility.